### PR TITLE
Add an interactive console executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.bundle/
 /.yardoc
+/.pryrc
 /Gemfile.lock
 /_yardoc/
 /coverage/

--- a/.sample.pryrc
+++ b/.sample.pryrc
@@ -1,0 +1,4 @@
+Veeqo.configure do |config|
+  config.api_host = "https://api.veeqo.com"
+  config.api_key = "SECRET_API_KEY"
+end

--- a/README.md
+++ b/README.md
@@ -86,6 +86,31 @@ Run the test suite
 bin/rspec
 ```
 
+### Play Box
+
+The API Play Box provides an interactive console so we can easily test out the
+actual API interaction. But before moving forward let's configure the key and
+API host (In case you wanna test on a mock server).
+
+Setup the client configuration.
+
+```sh
+cp .sample.pryrc .pryrc
+vim .pryrc
+```
+
+Start the console.
+
+```sh
+bin/console
+```
+
+Start playing with it.
+
+```ruby
+Veeqo::Order.list
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/veeqo. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/bin/console
+++ b/bin/console
@@ -6,9 +6,5 @@ require "veeqo"
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start
+require "pry"
+Pry.start

--- a/veeqo.gemspec
+++ b/veeqo.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.0"
+  spec.add_development_dependency "pry", "~> 0.10.3"
 end


### PR DESCRIPTION
We are stubbing API requests for our test suite, but sometime we need to interact with the actual API request and it's responses. This commit adds an easier way to play with the actual API in the console, lets start by running `bin/console`.

To make it more easier, it also provides us a `.sample.pryrc` and all we need do is copy it as `.pryrc` and set your keys.