### PR TITLE
Add interface to update an order

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ payment_attributes = {
 Veeqo::Order.find(order_id)
 ```
 
+#### Update order details
+
+```ruby
+Veeqo::Order.update(order_id, new_attributes)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/client.rb
+++ b/lib/veeqo/client.rb
@@ -46,4 +46,8 @@ module Veeqo
   def self.post_resource(end_point, attributes)
     Client.new(:post, end_point, attributes).execute
   end
+
+  def self.put_resource(end_point, attributes)
+    Client.new(:put, end_point, attributes).execute
+  end
 end

--- a/lib/veeqo/order.rb
+++ b/lib/veeqo/order.rb
@@ -19,5 +19,11 @@ module Veeqo
 
       Veeqo.post_resource("orders", order: required_attributes.merge(attrs))
     end
+
+    def self.update(order_id, attributes = {})
+      Veeqo.put_resource(
+        ["orders", order_id].join("/"), attributes
+      )
+    end
   end
 end

--- a/lib/veeqo/response.rb
+++ b/lib/veeqo/response.rb
@@ -9,9 +9,19 @@ module Veeqo
     end
 
     def parse
-      JSON.parse(response, object_class: ResponseObject)
+      parse_response_content
     rescue JSON::ParserError => error
       ResponseObject.new(error: error, content: "")
+    end
+
+    private
+
+    def parse_response_content
+      if response.code == 204
+        ResponseObject.new(successful?: true, content: "")
+      else
+        JSON.parse(response, object_class: ResponseObject)
+      end
     end
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe Veeqo::Client do
     end
   end
 
+  describe ".put_resource" do
+    it "submit the resource via :put" do
+      stub_put_ping_request
+      resource = Veeqo.put_resource("ping", data: "ping")
+
+      expect(resource.data).to eq("Pong!")
+    end
+  end
+
   def stub_get_ping_request
     stub_api_response(
       :get, "ping", status: 200, filename: "ping"
@@ -28,6 +37,12 @@ RSpec.describe Veeqo::Client do
   def stub_post_ping_request
     stub_api_response(
       :post, "ping", status: 200, filename: "ping", data: { data: "ping" }
+    )
+  end
+
+  def stub_put_ping_request
+    stub_api_response(
+      :put, "ping", status: 200, filename: "ping", data: { data: "ping" }
     )
   end
 end

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe Veeqo::Order do
     end
   end
 
+  describe ".update" do
+    it "updates the order with new attributes" do
+      order_id = 123
+      new_attributes = { number: "Inv #123" }
+
+      stub_veeqo_order_update_api(order_id, new_attributes)
+      order_update = Veeqo::Order.update(order_id, new_attributes)
+
+      expect(order_update.successful?).to be_truthy
+    end
+  end
+
   def order_attributes
     {
       channel_id: "3525",

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -28,6 +28,16 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_order_update_api(order_id, attributes)
+    stub_api_response(
+      :put,
+      ["orders", order_id].join("/"),
+      data: attributes,
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)


### PR DESCRIPTION
This commit adds the interface to update the order, it expects two arguments, one is `order_id` and another is `new_attributes`, and if the order update request is successful then it will return an object with a `successful?` status in it.

```ruby
Veeqo::Order.update(order_id, new_attributes)
```