### PR TITLE
Add interface to delete an order

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ Veeqo::Order.find(order_id)
 Veeqo::Order.update(order_id, new_attributes)
 ```
 
+#### Delete an order
+
+```ruby
+Veeqo::Order.delete(order_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/client.rb
+++ b/lib/veeqo/client.rb
@@ -50,4 +50,8 @@ module Veeqo
   def self.put_resource(end_point, attributes)
     Client.new(:put, end_point, attributes).execute
   end
+
+  def self.delete_resource(end_point, resource_id)
+    Client.new(:delete, [end_point, resource_id].join("/")).execute
+  end
 end

--- a/lib/veeqo/order.rb
+++ b/lib/veeqo/order.rb
@@ -25,5 +25,9 @@ module Veeqo
         ["orders", order_id].join("/"), attributes
       )
     end
+
+    def self.delete(order_id)
+      Veeqo.delete_resource("orders", order_id)
+    end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe Veeqo::Client do
     end
   end
 
+  describe ".delete_resource" do
+    it "submits the requests via :delete" do
+      stub_delete_ping_request
+      resource = Veeqo.delete_resource("ping", 1)
+
+      expect(resource.successful?).to be_truthy
+    end
+  end
+
   def stub_get_ping_request
     stub_api_response(
       :get, "ping", status: 200, filename: "ping"
@@ -43,6 +52,12 @@ RSpec.describe Veeqo::Client do
   def stub_put_ping_request
     stub_api_response(
       :put, "ping", status: 200, filename: "ping", data: { data: "ping" }
+    )
+  end
+
+  def stub_delete_ping_request
+    stub_api_response(
+      :delete, "ping/1", status: 204, filename: "empty"
     )
   end
 end

--- a/spec/order_spec.rb
+++ b/spec/order_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe Veeqo::Order do
     end
   end
 
+  describe ".find" do
+    it "retrieves a specific order" do
+      order_id = 123
+      stub_veeqo_order_find_api(order_id)
+      order = Veeqo::Order.find(order_id)
+
+      expect(order.number).not_to be_nil
+    end
+  end
+
   describe ".create" do
     it "creates a new order" do
       stub_veeqo_order_create_api(order_attributes)
@@ -33,16 +43,6 @@ RSpec.describe Veeqo::Order do
       expect(order.id).not_to be_nil
       expect(order.deliver_to.first_name).to eq("Sky")
       expect(order.payment.payment_type).not_to be_nil
-    end
-  end
-
-  describe ".find" do
-    it "retrieves a specific order" do
-      order_id = 123
-      stub_veeqo_order_find_api(order_id)
-      order = Veeqo::Order.find(order_id)
-
-      expect(order.number).not_to be_nil
     end
   end
 
@@ -55,6 +55,16 @@ RSpec.describe Veeqo::Order do
       order_update = Veeqo::Order.update(order_id, new_attributes)
 
       expect(order_update.successful?).to be_truthy
+    end
+  end
+
+  describe ".delete" do
+    it "deletes a specific order" do
+      order_id = 123
+      stub_veeqo_order_delete_api(order_id)
+      order_delete = Veeqo::Order.delete(order_id)
+
+      expect(order_delete.successful?).to be_truthy
     end
   end
 

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -38,6 +38,15 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_order_delete_api(order_id)
+    stub_api_response(
+      :delete,
+      ["orders", order_id].join("/"),
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)


### PR DESCRIPTION
This commit adds the interface to delete an order, and if the request is successful then it will returns an object with the `successful?` status `true` in it. Usage

```ruby
Veeqo::Order.delete(order_id)
```