### PR TITLE
Add interface to update a product

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ image_one_attributes = {
 Veeqo::Product.find(product_id)
 ```
 
+#### Update product details
+
+```ruby
+Veeqo::Product.update(product_id, new_attributes)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/product.rb
+++ b/lib/veeqo/product.rb
@@ -21,5 +21,11 @@ module Veeqo
         "products", product: required_attributes.merge(attributes)
       )
     end
+
+    def self.update(product_id, attributes)
+      Veeqo.put_resource(
+        ["products", product_id].join("/"), product: attributes
+      )
+    end
   end
 end

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe Veeqo::Product do
     end
   end
 
+  describe ".update" do
+    it "updates the product with new attributes" do
+      product_id = 123
+      new_attributes = { title: "Best T Shirt" }
+
+      stub_veeqo_product_update_api(product_id, new_attributes)
+      product_update = Veeqo::Product.update(product_id, new_attributes)
+
+      expect(product_update.successful?).to be_truthy
+    end
+  end
+
   def product_attributes
     {
       title: "T Shirt",

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -76,6 +76,16 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_product_update_api(product_id, new_attributes)
+    stub_api_response(
+      :put,
+      ["products", product_id].join("/"),
+      data: { product: new_attributes },
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)


### PR DESCRIPTION
This commit adds the interface to update a specific product using the Veeqo API. Usage

```ruby
Veeqo::Product.update(product_id, new_attributes)
```