### PR TITLE
Add interface to delete a product

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ Veeqo::Product.find(product_id)
 Veeqo::Product.update(product_id, new_attributes)
 ```
 
+#### Delete a product
+
+```ruby
+Veeqo::Product.delete(product_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/product.rb
+++ b/lib/veeqo/product.rb
@@ -27,5 +27,9 @@ module Veeqo
         ["products", product_id].join("/"), product: attributes
       )
     end
+
+    def self.delete(product_id)
+      Veeqo.delete_resource("products", product_id)
+    end
   end
 end

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe Veeqo::Product do
     end
   end
 
+  describe ".delete" do
+    it "deletes the specific product" do
+      product_id = 123
+      stub_veeqo_product_delete_api(product_id)
+      product_delete = Veeqo::Product.delete(product_id)
+
+      expect(product_delete.successful?).to be_truthy
+    end
+  end
+
   def product_attributes
     {
       title: "T Shirt",

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -86,6 +86,12 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_product_delete_api(id)
+    stub_api_response(
+      :delete, ["products", id].join("/"), filename: "empty", status: 204
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)


### PR DESCRIPTION
This commit adds the interface to delete a specific using the Veeqo API. Usage

```ruby
Veeqo::Product.delete(product_id)
```