### PR TITLE
Add interface to update a supplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ Veeqo::Supplier.create(name: "ACME")
 Veeqo::Supplier.find(supplier_id)
 ```
 
+#### Update a supplier details
+
+```ruby
+Veeqo::Supplier.update(supplier_id, new_attributes_hash)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/base.rb
+++ b/lib/veeqo/base.rb
@@ -23,5 +23,11 @@ module Veeqo
     def create_resource(attributes)
       Veeqo.post_resource(end_point, attributes)
     end
+
+    def update_resource(resource_id, attributes)
+      Veeqo.put_resource(
+        [end_point, resource_id].join("/"), attributes
+      )
+    end
   end
 end

--- a/lib/veeqo/supplier.rb
+++ b/lib/veeqo/supplier.rb
@@ -12,6 +12,10 @@ module Veeqo
       create_resource(name: name)
     end
 
+    def update(supplier_id, attributes)
+      update_resource(supplier_id, attributes)
+    end
+
     private
 
     def end_point

--- a/spec/supplier_spec.rb
+++ b/spec/supplier_spec.rb
@@ -47,4 +47,16 @@ RSpec.describe Veeqo::Supplier do
       expect(supplier.name).to eq(supplier_attributes[:name])
     end
   end
+
+  describe ".update" do
+    it "updates the supplier with new attributes" do
+      supplier_id = 123
+      new_attributes = { name: "ACME" }
+
+      stub_veeqo_supplier_update_api(supplier_id, new_attributes)
+      supplier_update = Veeqo::Supplier.update(supplier_id, new_attributes)
+
+      expect(supplier_update.successful?).to be_truthy
+    end
+  end
 end

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -128,6 +128,16 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_supplier_update_api(id, attributes)
+    stub_api_response(
+      :put,
+      ["suppliers", id].join("/"),
+      data: attributes,
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)


### PR DESCRIPTION
This commit adds the interface to update a specific supplier with some new attributes. Usage

```ruby
Veeqo::Supplier.update(supplier_id, new_attributes)
```