### PR TITLE
Add interface to delete a supplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ Veeqo::Supplier.find(supplier_id)
 Veeqo::Supplier.update(supplier_id, new_attributes_hash)
 ```
 
+#### Delete a supplier
+
+```ruby
+Veeqo::Supplier.delete(supplier_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/base.rb
+++ b/lib/veeqo/base.rb
@@ -29,5 +29,9 @@ module Veeqo
         [end_point, resource_id].join("/"), attributes
       )
     end
+
+    def delete_resource(resource_id)
+      Veeqo.delete_resource(end_point, resource_id)
+    end
   end
 end

--- a/lib/veeqo/supplier.rb
+++ b/lib/veeqo/supplier.rb
@@ -16,6 +16,10 @@ module Veeqo
       update_resource(supplier_id, attributes)
     end
 
+    def delete(supplier_id)
+      delete_resource(supplier_id)
+    end
+
     private
 
     def end_point

--- a/spec/supplier_spec.rb
+++ b/spec/supplier_spec.rb
@@ -59,4 +59,15 @@ RSpec.describe Veeqo::Supplier do
       expect(supplier_update.successful?).to be_truthy
     end
   end
+
+  describe ".delete" do
+    it "deletes the specified supplier" do
+      supplier_id = 123
+
+      stub_veeqo_supplier_delete_api(supplier_id)
+      supplier_delete = Veeqo::Supplier.delete(supplier_id)
+
+      expect(supplier_delete.successful?).to be_truthy
+    end
+  end
 end

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -138,6 +138,12 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_supplier_delete_api(id)
+    stub_api_response(
+      :delete, ["suppliers", id].join("/"), status: 204, filename: "empty"
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)


### PR DESCRIPTION
This commit adds an interface to delete the specific supplier using the Veeqo API. The usage is as simple as

```ruby
Veeqo::Supplier.delete(supplier_id)
```