### PR TITLE
Remove resource related duplications

### DIFF
--- a/lib/veeqo/order.rb
+++ b/lib/veeqo/order.rb
@@ -1,33 +1,35 @@
 module Veeqo
   class Order < Base
     def list(filters = {})
-      Veeqo.get_resource("orders", filters)
+      list_resource(filters)
     end
 
     def find(order_id)
-      Veeqo.get_resource(
-        ["orders", order_id].join("/"),
-      )
+      find_resource(order_id)
     end
 
-    def create(channel_id:, customer_id:, delivery_method_id:, **attrs)
+    def create(channel_id:, customer_id:, delivery_method_id:, **attributes)
       required_attributes = {
         channel_id: channel_id,
         customer_id: customer_id,
         delivery_method_id: delivery_method_id,
       }
 
-      Veeqo.post_resource("orders", order: required_attributes.merge(attrs))
+      create_resource(order: required_attributes.merge(attributes))
     end
 
     def update(order_id, attributes = {})
-      Veeqo.put_resource(
-        ["orders", order_id].join("/"), attributes
-      )
+      update_resource(order_id, attributes)
     end
 
     def delete(order_id)
-      Veeqo.delete_resource("orders", order_id)
+      delete_resource(order_id)
+    end
+
+    private
+
+    def end_point
+      "orders"
     end
   end
 end

--- a/lib/veeqo/product.rb
+++ b/lib/veeqo/product.rb
@@ -1,13 +1,11 @@
 module Veeqo
   class Product < Base
     def list(filters = {})
-      Veeqo.get_resource("products", filters)
+      list_resource(filters)
     end
 
     def find(product_id)
-      Veeqo.get_resource(
-        ["products", product_id].join("/"),
-      )
+      find_resource(product_id)
     end
 
     def create(title:, variants:, images: [], **attributes)
@@ -17,19 +15,21 @@ module Veeqo
         images_attributes: images,
       }
 
-      Veeqo.post_resource(
-        "products", product: required_attributes.merge(attributes)
-      )
+      create_resource(product: required_attributes.merge(attributes))
     end
 
     def update(product_id, attributes)
-      Veeqo.put_resource(
-        ["products", product_id].join("/"), product: attributes
-      )
+      update_resource(product_id, product: attributes)
     end
 
     def delete(product_id)
-      Veeqo.delete_resource("products", product_id)
+      delete_resource(product_id)
+    end
+
+    private
+
+    def end_point
+      "products"
     end
   end
 end

--- a/lib/veeqo/purchase_order.rb
+++ b/lib/veeqo/purchase_order.rb
@@ -1,7 +1,13 @@
 module Veeqo
   class PurchaseOrder < Base
     def list(filters = {})
-      Veeqo.get_resource("purchase_orders", filters)
+      list_resource(filters)
+    end
+
+    private
+
+    def end_point
+      "purchase_orders"
     end
   end
 end


### PR DESCRIPTION
Currently, we were using the API communication related methods in each of the model, but now we have a `Base` model to inherit with. So let's remove resource request related duplication and this will also make it easier in long run as we are extracting the communication behavior in one place.