### PR TITLE
Add interface to update a company

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ Information about current company
 Veeqo::Company.find
 ```
 
+#### Update company details
+
+```ruby
+Veeqo::Company.update(new_attributes_hash)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/company.rb
+++ b/lib/veeqo/company.rb
@@ -4,6 +4,10 @@ module Veeqo
       Veeqo.get_resource(end_point)
     end
 
+    def update(attributes)
+      Veeqo.put_resource(end_point, attributes)
+    end
+
     private
 
     def end_point

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -150,6 +150,12 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_company_update_api(attributes)
+    stub_api_response(
+      :put, "current_company", data: attributes, filename: "empty", status: 204
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/company_spec.rb
+++ b/spec/veeqo/company_spec.rb
@@ -9,4 +9,15 @@ RSpec.describe Veeqo::Company do
       expect(company.name).not_to be_nil
     end
   end
+
+  describe ".update" do
+    it "updates the current company with new attributes" do
+      new_attributes = { name: "ACME" }
+
+      stub_veeqo_company_update_api(new_attributes)
+      company_update = Veeqo::Company.update(new_attributes)
+
+      expect(company_update.successful?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the interface to update the current company with some new attributes. To keep consistency it usages the `update` API without any `resource_id` in it. Usage

```ruby
Veeqo::Company.update(new_attributes)
```