### PR TITLE
Add interface to create a warehouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,12 @@ Resources related to the warehouses in the API.
 Veeqo::Warehouse.list(page: 1, page_size: 12)
 ```
 
+#### Create a new warehouse
+
+```ruby
+Veeqo::Warehouse.create(name: "My Warehouse")
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/warehouse.rb
+++ b/lib/veeqo/warehouse.rb
@@ -4,6 +4,10 @@ module Veeqo
       list_resource(filters)
     end
 
+    def create(name:)
+      create_resource(name: name)
+    end
+
     private
 
     def end_point

--- a/spec/fixtures/warehouse_created.json
+++ b/spec/fixtures/warehouse_created.json
@@ -1,0 +1,4 @@
+{
+  "id": 123,
+  "name": "My Warehouse"
+}

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -162,6 +162,16 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_warehouse_create_api(attributes)
+    stub_api_response(
+      :post,
+      "warehouses",
+      data: attributes,
+      status: 200,
+      filename: "warehouse_created",
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/warehouse_spec.rb
+++ b/spec/veeqo/warehouse_spec.rb
@@ -24,4 +24,16 @@ RSpec.describe Veeqo::Warehouse do
       end
     end
   end
+
+  describe ".create" do
+    it "creates a new warehouse" do
+      warehouse_attributes = { name: "My Warehouse" }
+
+      stub_veeqo_warehouse_create_api(warehouse_attributes)
+      warehouse = Veeqo::Warehouse.create(warehouse_attributes)
+
+      expect(warehouse.id).not_to be_nil
+      expect(warehouse.name).to eq(warehouse_attributes[:name])
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the interface to create a new warehouse based on the attributes provided. To create a new warehouse use

```ruby
Veeqo::Warehouse.create(name: "My Warehouse")
```