### PR TITLE
Add interface to retrieve a warehouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,12 @@ Veeqo::Warehouse.list(page: 1, page_size: 12)
 Veeqo::Warehouse.create(name: "My Warehouse")
 ```
 
+#### View a warehouse details
+
+```ruby
+Veeqo::Warehouse.find(warehouse_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/warehouse.rb
+++ b/lib/veeqo/warehouse.rb
@@ -4,6 +4,10 @@ module Veeqo
       list_resource(filters)
     end
 
+    def find(warehouse_id)
+      find_resource(warehouse_id)
+    end
+
     def create(name:)
       create_resource(name: name)
     end

--- a/spec/fixtures/warehouse.json
+++ b/spec/fixtures/warehouse.json
@@ -1,0 +1,3 @@
+{
+  "name": "My Warehouse"
+}

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -167,8 +167,14 @@ module FakeVeeqoApi
       :post,
       "warehouses",
       data: attributes,
-      status: 200,
+      status: 201,
       filename: "warehouse_created",
+    )
+  end
+
+  def stub_veeqo_warehouse_find_api(id)
+    stub_api_response(
+      :get, ["warehouses", id].join("/"), filename: "warehouse", status: 200
     )
   end
 

--- a/spec/veeqo/warehouse_spec.rb
+++ b/spec/veeqo/warehouse_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe Veeqo::Warehouse do
     end
   end
 
+  describe ".find" do
+    it "retrieves the specific warehouse details" do
+      warehouse_id = 123
+
+      stub_veeqo_warehouse_find_api(warehouse_id)
+      warehouse = Veeqo::Warehouse.find(warehouse_id)
+
+      expect(warehouse.name).not_to be_nil
+    end
+  end
+
   describe ".create" do
     it "creates a new warehouse" do
       warehouse_attributes = { name: "My Warehouse" }


### PR DESCRIPTION
This commit adds the interface to retrieve the details of a specific warehouse. The usages is as simple as

```ruby
Veeqo::Warehouse.find(warehouse_id)
```