### PR TITLE
Add interface to update a warehouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ Veeqo::Warehouse.create(name: "My Warehouse")
 Veeqo::Warehouse.find(warehouse_id)
 ```
 
+#### Update warehouse details
+
+```ruby
+Veeqo::Warehouse.update(warehouse_id, new_attributes_hash)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/warehouse.rb
+++ b/lib/veeqo/warehouse.rb
@@ -12,6 +12,10 @@ module Veeqo
       create_resource(name: name)
     end
 
+    def update(warehouse_id, attributes)
+      update_resource(warehouse_id, attributes)
+    end
+
     private
 
     def end_point

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -178,6 +178,16 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_warehouse_update_api(id, attributes)
+    stub_api_response(
+      :put,
+      ["warehouses", id].join("/"),
+      data: attributes,
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/warehouse_spec.rb
+++ b/spec/veeqo/warehouse_spec.rb
@@ -47,4 +47,16 @@ RSpec.describe Veeqo::Warehouse do
       expect(warehouse.name).to eq(warehouse_attributes[:name])
     end
   end
+
+  describe ".update" do
+    it "updates a warehouse with new attributes" do
+      warehouse_id = 123
+      new_attributes = { name: "My Warehouse" }
+
+      stub_veeqo_warehouse_update_api(warehouse_id, new_attributes)
+      warehouse_update = Veeqo::Warehouse.update(warehouse_id, new_attributes)
+
+      expect(warehouse_update.successful?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the interface to update the details for the specific warehouse. Usage

```ruby
Veeqo::Warehouse.update(warehouse_id, new_attributes)
```