### PR TITLE
Add interface for warehouse deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,11 +292,17 @@ Veeqo::Warehouse.create(name: "My Warehouse")
 Veeqo::Warehouse.find(warehouse_id)
 ```
 
-#### Update warehouse details
+#### Update a warehouse details
+
+```ruby
+Veeqo::Warehouse.delete(warehouse_id)
+```
 
 ```ruby
 Veeqo::Warehouse.update(warehouse_id, new_attributes_hash)
 ```
+
+#### Delete a warehouse
 
 ## Development
 

--- a/lib/veeqo/warehouse.rb
+++ b/lib/veeqo/warehouse.rb
@@ -16,6 +16,10 @@ module Veeqo
       update_resource(warehouse_id, attributes)
     end
 
+    def delete(warehouse_id)
+      delete_resource(warehouse_id)
+    end
+
     private
 
     def end_point

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -188,6 +188,12 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_warehouse_delete_api(id)
+    stub_api_response(
+      :delete, ["warehouses", id].join("/"), filename: "empty", status: 204
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/warehouse_spec.rb
+++ b/spec/veeqo/warehouse_spec.rb
@@ -59,4 +59,15 @@ RSpec.describe Veeqo::Warehouse do
       expect(warehouse_update.successful?).to be_truthy
     end
   end
+
+  describe ".delete" do
+    it "deletes the specified warehouse" do
+      warehouse_id = 123
+
+      stub_veeqo_warehouse_delete_api(warehouse_id)
+      warehouse_deletion = Veeqo::Warehouse.delete(warehouse_id)
+
+      expect(warehouse_deletion.successful?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the interface to delete a specific warehouse using the Veeqo API. To delete a warehouse simply use

```ruby
Veeqo::Warehouse.delete(warehouse_id)
```