### PR TITLE
Add interface to create a customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,25 @@ Resources related to the customers in the API.
 Veeqo::Customer.list(page: 1, page_size: 12)
 ```
 
+#### Create a customer
+
+```ruby
+Veeqo::Customer.create(
+  email: "customer@example.com",
+  phone: "01792 720740",
+  mobile: "07329023903",
+  billing_address: {
+    first_name: "John",
+    last_name: "Doe",
+    company: "FooBar Ltd",
+    address1: "221 High Street Lane",
+    city: "Swansea",
+    country: "GB",
+    zip: "SA1 1NW",
+  }
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/customer.rb
+++ b/lib/veeqo/customer.rb
@@ -4,6 +4,11 @@ module Veeqo
       list_resource(filters)
     end
 
+    def create(email:, **attributes)
+      required_attributes = { email: email }
+      create_resource(customer: required_attributes.merge(attributes))
+    end
+
     private
 
     def end_point

--- a/spec/fixtures/customer_created.json
+++ b/spec/fixtures/customer_created.json
@@ -1,0 +1,15 @@
+{
+  "id": 123,
+  "email": "customer@example.com",
+  "phone": "01792 720740",
+  "mobile": "07329023903",
+  "billing_address_attributes": {
+    "first_name": "Foo",
+    "last_name": "Bar",
+    "address1": "FooBar Lane",
+    "address2": "",
+    "city": "Swansea",
+    "country": "GB",
+    "zip": "SA1 1NW"
+  }
+}

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -200,6 +200,16 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_customer_create_api(attributes)
+    stub_api_response(
+      :post,
+      "customers",
+      data: { customer: attributes },
+      filename: "customer_created",
+      status: 201,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/customer_spec.rb
+++ b/spec/veeqo/customer_spec.rb
@@ -25,4 +25,31 @@ RSpec.describe Veeqo::Customer do
       end
     end
   end
+
+  describe ".create" do
+    it "creates a new customer" do
+      stub_veeqo_customer_create_api(customer_attributes)
+      customer = Veeqo::Customer.create(customer_attributes)
+
+      expect(customer.id).to eq(123)
+      expect(customer.email).to eq(customer_attributes[:email])
+    end
+  end
+
+  def customer_attributes
+    {
+      email: "customer@example.com",
+      phone: "01792 720740",
+      mobile: "07329023903",
+      billing_address: {
+        first_name: "John",
+        last_name: "Doe",
+        company: "FooBar Ltd",
+        address1: "221 High Street Lane",
+        city: "Swansea",
+        country: "GB",
+        zip: "SA1 1NW",
+      },
+    }
+  end
 end


### PR DESCRIPTION
This commit adds the interface to create a new customer using the Veeqo API. To create a new customer simply use

```ruby
Veeqo::Customer.create(
  email: "customer@example.com",
  phone: "01792 720740",
  mobile: "07329023903",
  billing_address: {
    first_name: "John",
    last_name: "Doe",
    company: "FooBar Ltd",
    address1: "221 High Street Lane",
    city: "Swansea",
    country: "GB",
    zip: "SA1 1NW",
  }
)
```