### PR TITLE
Add interface to retrieve a customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,12 @@ Veeqo::Customer.create(
 )
 ```
 
+#### View a customer details
+
+```ruby
+Veeqo::Customer.find(customer_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/customer.rb
+++ b/lib/veeqo/customer.rb
@@ -4,6 +4,10 @@ module Veeqo
       list_resource(filters)
     end
 
+    def find(customer_id)
+      find_resource(customer_id)
+    end
+
     def create(email:, **attributes)
       required_attributes = { email: email }
       create_resource(customer: required_attributes.merge(attributes))

--- a/spec/fixtures/customer.json
+++ b/spec/fixtures/customer.json
@@ -1,0 +1,4 @@
+{
+  "id": 123,
+  "email": "customer@example.com"
+}

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -200,6 +200,12 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_customer_find_api(id)
+    stub_api_response(
+      :get, ["customers", id].join("/"), filename: "customer", status: 200
+    )
+  end
+
   def stub_veeqo_customer_create_api(attributes)
     stub_api_response(
       :post,

--- a/spec/veeqo/customer_spec.rb
+++ b/spec/veeqo/customer_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Veeqo::Customer do
     end
   end
 
+  describe ".find" do
+    it "retrives the details for a customer" do
+      customer_id = 123
+
+      stub_veeqo_customer_find_api(customer_id)
+      customer = Veeqo::Customer.find(customer_id)
+
+      expect(customer.id).to eq(123)
+      expect(customer.email).not_to be_nil
+    end
+  end
+
   describe ".create" do
     it "creates a new customer" do
       stub_veeqo_customer_create_api(customer_attributes)


### PR DESCRIPTION
This commit adds the interface to retrieve the details for a specific customer. To retrieve a customer details use

```ruby
Veeqo::Customer.find(customer_id)
```