### PR TITLE
Add interface to update a customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,14 @@ Veeqo::Customer.create(
 Veeqo::Customer.find(customer_id)
 ```
 
+#### Update a customer details
+
+```ruby
+Veeqo::Customer.update(
+  customer_id, new_attributes_hash
+)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/customer.rb
+++ b/lib/veeqo/customer.rb
@@ -13,6 +13,14 @@ module Veeqo
       create_resource(customer: required_attributes.merge(attributes))
     end
 
+    def update(customer_id, email:, **attributes)
+      required_attributes = { email: email }
+
+      update_resource(
+        customer_id, customer: required_attributes.merge(attributes)
+      )
+    end
+
     private
 
     def end_point

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -216,6 +216,16 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_customer_update_api(id, attributes)
+    stub_api_response(
+      :put,
+      ["customers", id].join("/"),
+      data: { customer: attributes },
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/customer_spec.rb
+++ b/spec/veeqo/customer_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe Veeqo::Customer do
     end
   end
 
+  describe ".update" do
+    it "updates the customer with new attributes" do
+      customer_id = 123
+      new_attributes = { email: "customer@example.com" }
+
+      stub_veeqo_customer_update_api(customer_id, new_attributes)
+      customer_update = Veeqo::Customer.update(customer_id, new_attributes)
+
+      expect(customer_update.successful?).to be_truthy
+    end
+  end
+
   def customer_attributes
     {
       email: "customer@example.com",


### PR DESCRIPTION
This commit adds the interface to update a specific customer using the Veeqo API. To update an existing customer use

```ruby
Veeqo::Customer.update(customer_id, new_attributes_hash)
```