### PR TITLE
Add interface to delete a customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,12 @@ Veeqo::Customer.update(
 )
 ```
 
+#### Delete a customer
+
+```ruby
+Veeqo::Customer.delete(customer_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/customer.rb
+++ b/lib/veeqo/customer.rb
@@ -21,6 +21,10 @@ module Veeqo
       )
     end
 
+    def delete(customer_id)
+      delete_resource(customer_id)
+    end
+
     private
 
     def end_point

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -226,6 +226,12 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_customer_delete_api(id)
+    stub_api_response(
+      :delete, ["customers", id].join("/"), filename: "empty", status: 204
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/customer_spec.rb
+++ b/spec/veeqo/customer_spec.rb
@@ -60,6 +60,17 @@ RSpec.describe Veeqo::Customer do
     end
   end
 
+  describe ".delete" do
+    it "deletes the specified customer" do
+      customer_id = 123
+
+      stub_veeqo_customer_delete_api(customer_id)
+      customer_deletion = Veeqo::Customer.delete(customer_id)
+
+      expect(customer_deletion.successful?).to be_truthy
+    end
+  end
+
   def customer_attributes
     {
       email: "customer@example.com",


### PR DESCRIPTION
This commit adds the interface to delete a customer using the Veeqo API. To delete a customer use

```ruby
Veeqo::Customer.delete(customer_id)
```