### PR TITLE
Group common actions to a module

### DIFF
--- a/lib/veeqo/actions/base.rb
+++ b/lib/veeqo/actions/base.rb
@@ -1,0 +1,13 @@
+require "veeqo/actions/list"
+require "veeqo/actions/find"
+require "veeqo/actions/delete"
+
+module Veeqo
+  module Actions
+    module Base
+      include Veeqo::Actions::List
+      include Veeqo::Actions::Find
+      include Veeqo::Actions::Delete
+    end
+  end
+end

--- a/lib/veeqo/base.rb
+++ b/lib/veeqo/base.rb
@@ -1,6 +1,4 @@
-require "veeqo/actions/list"
-require "veeqo/actions/find"
-require "veeqo/actions/delete"
+require "veeqo/actions/base"
 
 module Veeqo
   class Base

--- a/lib/veeqo/customer.rb
+++ b/lib/veeqo/customer.rb
@@ -1,8 +1,6 @@
 module Veeqo
   class Customer < Base
-    include Veeqo::Actions::List
-    include Veeqo::Actions::Find
-    include Veeqo::Actions::Delete
+    include Veeqo::Actions::Base
 
     def create(email:, **attributes)
       required_attributes = { email: email }

--- a/lib/veeqo/order.rb
+++ b/lib/veeqo/order.rb
@@ -1,8 +1,6 @@
 module Veeqo
   class Order < Base
-    include Veeqo::Actions::List
-    include Veeqo::Actions::Find
-    include Veeqo::Actions::Delete
+    include Veeqo::Actions::Base
 
     def create(channel_id:, customer_id:, delivery_method_id:, **attributes)
       required_attributes = {

--- a/lib/veeqo/product.rb
+++ b/lib/veeqo/product.rb
@@ -1,8 +1,6 @@
 module Veeqo
   class Product < Base
-    include Veeqo::Actions::List
-    include Veeqo::Actions::Find
-    include Veeqo::Actions::Delete
+    include Veeqo::Actions::Base
 
     def create(title:, variants:, images: [], **attributes)
       required_attributes = {

--- a/lib/veeqo/supplier.rb
+++ b/lib/veeqo/supplier.rb
@@ -1,8 +1,6 @@
 module Veeqo
   class Supplier < Base
-    include Veeqo::Actions::List
-    include Veeqo::Actions::Find
-    include Veeqo::Actions::Delete
+    include Veeqo::Actions::Base
 
     def create(name:)
       create_resource(name: name)

--- a/lib/veeqo/warehouse.rb
+++ b/lib/veeqo/warehouse.rb
@@ -1,8 +1,6 @@
 module Veeqo
   class Warehouse < Base
-    include Veeqo::Actions::List
-    include Veeqo::Actions::Find
-    include Veeqo::Actions::Delete
+    include Veeqo::Actions::Base
 
     def create(name:)
       create_resource(name: name)


### PR DESCRIPTION
In the gem, one behavior is common, that most of the resource models are using `list`, `find` and `delete` actions together. This commit group those common actions to a `Base` module, so all we need to do is include one module :).