### PR TITLE
Add interface to update a store

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,12 @@ Veeqo::Store.create(name: "Phone", type_code: "direct")
 Veeqo::Store.find(store_id)
 ```
 
+#### Update a store details
+
+```ruby
+Veeqo::Store.update(store_id, new_attributes_hash)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/store.rb
+++ b/lib/veeqo/store.rb
@@ -7,6 +7,10 @@ module Veeqo
       create_resource(name: name, type_code: type_code)
     end
 
+    def update(store_id, attributes)
+      update_resource(store_id, attributes)
+    end
+
     private
 
     def end_point

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -254,6 +254,16 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_store_update_api(id, attributes)
+    stub_api_response(
+      :put,
+      ["channels", id].join("/"),
+      data: attributes,
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/store_spec.rb
+++ b/spec/veeqo/store_spec.rb
@@ -35,4 +35,16 @@ RSpec.describe Veeqo::Store do
       expect(store.name).to eq(store_attributes[:name])
     end
   end
+
+  describe ".update" do
+    it "updates the store with new attributes" do
+      store_id = 123
+      new_attributes = { name: "Phone" }
+
+      stub_veeqo_store_update_api(store_id, new_attributes)
+      store_update = Veeqo::Store.update(store_id, new_attributes)
+
+      expect(store_update.successful?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the interface to update a store details using the Veeqo API. To update an existing store we can use

```ruby
Veeqo::Store.update(store_id, new_attributes_hash)
```