### PR TITLE
Add interface to delete a store

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,12 @@ Veeqo::Store.find(store_id)
 Veeqo::Store.update(store_id, new_attributes_hash)
 ```
 
+#### Delete a store
+
+```ruby
+Veeqo::Store.delete(store_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/store.rb
+++ b/lib/veeqo/store.rb
@@ -1,7 +1,6 @@
 module Veeqo
   class Store < Base
-    include Veeqo::Actions::List
-    include Veeqo::Actions::Find
+    include Veeqo::Actions::Base
 
     def create(name:, type_code:)
       create_resource(name: name, type_code: type_code)

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -264,6 +264,12 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_store_delete_api(id)
+    stub_api_response(
+      :delete, ["channels", id].join("/"), filename: "empty", status: 204
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/store_spec.rb
+++ b/spec/veeqo/store_spec.rb
@@ -47,4 +47,15 @@ RSpec.describe Veeqo::Store do
       expect(store_update.successful?).to be_truthy
     end
   end
+
+  describe ".delete" do
+    it "deletes the specified store" do
+      store_id = 123
+
+      stub_veeqo_store_delete_api(store_id)
+      store_deletion = Veeqo::Store.delete(store_id)
+
+      expect(store_deletion.successful?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the interface to delete a store, To delete an existing store simple use

```ruby
Veeqo::Store.delete(store_id)
```