### PR TITLE
Add delivery method creation interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,12 @@ Resources related to the delivery methods in the API
 Veeqo::DeliveryMethod.list(page: 1, page_size: 12)
 ```
 
+#### Create a delivery method
+
+```ruby
+Veeqo::DeliveryMethod.create(name: "Next Day Delivery")
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/delivery_method.rb
+++ b/lib/veeqo/delivery_method.rb
@@ -2,6 +2,10 @@ module Veeqo
   class DeliveryMethod < Base
     include Veeqo::Actions::List
 
+    def create(name:)
+      create_resource(name: name)
+    end
+
     private
 
     def end_point

--- a/spec/fixtures/delivery_method_created.json
+++ b/spec/fixtures/delivery_method_created.json
@@ -1,0 +1,4 @@
+{
+  "id": 123,
+  "name": "Next Day Delivery"
+}

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -280,6 +280,16 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_delivery_method_create_api(attributes)
+    stub_api_response(
+      :post,
+      "delivery_methods",
+      data: attributes,
+      filename: "delivery_method_created",
+      status: 201,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/delivery_method_spec.rb
+++ b/spec/veeqo/delivery_method_spec.rb
@@ -12,4 +12,16 @@ RSpec.describe Veeqo::DeliveryMethod do
       expect(delivery_methods.first.id).not_to be_nil
     end
   end
+
+  describe ".create" do
+    it "creates a new deliver method" do
+      attributes = { name: "Next Day Delivery" }
+
+      stub_veeqo_delivery_method_create_api(attributes)
+      delivery_method = Veeqo::DeliveryMethod.create(attributes)
+
+      expect(delivery_method.id).not_to be_nil
+      expect(delivery_method.name).to eq(attributes[:name])
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the interface to create a new delivery methods. To create a new delivery method simply use

```ruby
Veeqo::DeliveryMethod.create(name: "Next Day Delivery")
```