### PR TITLE
Retrieve a delivery method details

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,12 @@ Veeqo::DeliveryMethod.list(page: 1, page_size: 12)
 Veeqo::DeliveryMethod.create(name: "Next Day Delivery")
 ```
 
+#### View a delivery method details
+
+```ruby
+Veeqo::DeliveryMethod.find(delivery_method_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/delivery_method.rb
+++ b/lib/veeqo/delivery_method.rb
@@ -1,6 +1,7 @@
 module Veeqo
   class DeliveryMethod < Base
     include Veeqo::Actions::List
+    include Veeqo::Actions::Find
 
     def create(name:)
       create_resource(name: name)

--- a/spec/fixtures/delivery_method.json
+++ b/spec/fixtures/delivery_method.json
@@ -1,0 +1,3 @@
+{
+  "name": "Next Day Delivery"
+}

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -290,6 +290,15 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_delivery_method_find_api(id)
+    stub_api_response(
+      :get,
+      ["delivery_methods", id].join("/"),
+      filename: "delivery_method",
+      status: 200,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/delivery_method_spec.rb
+++ b/spec/veeqo/delivery_method_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe Veeqo::DeliveryMethod do
     end
   end
 
+  describe ".find" do
+    it "retrieves the details for a delivery method" do
+      delivery_method_id = 123
+
+      stub_veeqo_delivery_method_find_api(delivery_method_id)
+      delivery_method = Veeqo::DeliveryMethod.find(delivery_method_id)
+
+      expect(delivery_method.name).not_to be_nil
+    end
+  end
+
   describe ".create" do
     it "creates a new deliver method" do
       attributes = { name: "Next Day Delivery" }


### PR DESCRIPTION
This commit adds the interface to retrieve the details for a specific delivery method. To retrieve the details we can use

```ruby
Veeqo::DeliveryMethod.find(delivery_method_id)
```