### PR TITLE
Update delivery method interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,12 @@ Veeqo::DeliveryMethod.create(name: "Next Day Delivery")
 Veeqo::DeliveryMethod.find(delivery_method_id)
 ```
 
+#### Update a delivery method
+
+```ruby
+Veeqo::DeliveryMethod.update(delivery_method_id, new_attributes_hash)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/delivery_method.rb
+++ b/lib/veeqo/delivery_method.rb
@@ -7,6 +7,10 @@ module Veeqo
       create_resource(name: name)
     end
 
+    def update(delivery_method_id, name:)
+      update_resource(delivery_method_id, name: name)
+    end
+
     private
 
     def end_point

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -299,6 +299,16 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_delivery_method_update_api(id, attributes)
+    stub_api_response(
+      :put,
+      ["delivery_methods", id].join("/"),
+      data: attributes,
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/delivery_method_spec.rb
+++ b/spec/veeqo/delivery_method_spec.rb
@@ -35,4 +35,18 @@ RSpec.describe Veeqo::DeliveryMethod do
       expect(delivery_method.name).to eq(attributes[:name])
     end
   end
+
+  describe ".update" do
+    it "updates a delivery method with new attributes" do
+      delivery_method_id = 123
+      new_attributes = { name: "Next Day Delivery" }
+
+      stub_veeqo_delivery_method_update_api(delivery_method_id, new_attributes)
+      delivery_method_update = Veeqo::DeliveryMethod.update(
+        delivery_method_id, new_attributes
+      )
+
+      expect(delivery_method_update.successful?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the interface to update an existing delivery method using the Veeqo API. To update a delivery method use

```ruby
Veeqo::DeliveryMethod.update(
  delivery_method_id, new_attributes_hash
)
```