### PR TITLE
Add delivery method deletion interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,12 @@ Veeqo::DeliveryMethod.find(delivery_method_id)
 Veeqo::DeliveryMethod.update(delivery_method_id, new_attributes_hash)
 ```
 
+#### Delete a delivery method
+
+```ruby
+Veeqo::DeliveryMethod.delete(delivery_method_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/delivery_method.rb
+++ b/lib/veeqo/delivery_method.rb
@@ -1,7 +1,6 @@
 module Veeqo
   class DeliveryMethod < Base
-    include Veeqo::Actions::List
-    include Veeqo::Actions::Find
+    include Veeqo::Actions::Base
 
     def create(name:)
       create_resource(name: name)

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -309,6 +309,15 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_delivery_method_delete_api(id)
+    stub_api_response(
+      :delete,
+      ["delivery_methods", id].join("/"),
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/delivery_method_spec.rb
+++ b/spec/veeqo/delivery_method_spec.rb
@@ -49,4 +49,17 @@ RSpec.describe Veeqo::DeliveryMethod do
       expect(delivery_method_update.successful?).to be_truthy
     end
   end
+
+  describe ".delete" do
+    it "deletes a specific delivery method" do
+      delivery_method_id = 123
+
+      stub_veeqo_delivery_method_delete_api(delivery_method_id)
+      delivery_method_deletion = Veeqo::DeliveryMethod.delete(
+        delivery_method_id,
+      )
+
+      expect(delivery_method_deletion.successful?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the interface to delete a specific delivery method. To delete an existing delivery method we can use

```ruby
Veeqo::DeliveryMethod.delete(delivery_method_id)
```