### PR TITLE
Add interface for shipment deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,12 @@ Veeqo::Shipment.create(
 )
 ```
 
+#### Delete a shipment
+
+```ruby
+Veeqo::Shipment.delete(shipment_id)
+```
+
 ## Development
 
 We are following Sandi Metz's Rules for this gem, you can read the

--- a/lib/veeqo/shipment.rb
+++ b/lib/veeqo/shipment.rb
@@ -1,5 +1,7 @@
 module Veeqo
   class Shipment < Base
+    include Veeqo::Actions::Delete
+
     def create(order_id:, allocation_id:, shipment:)
       create_resource(
         order_id: order_id,

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -332,6 +332,12 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_shipment_delete_api(id)
+    stub_api_response(
+      :delete, ["shipments", id].join("/"), filename: "empty", status: 204
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/shipment_spec.rb
+++ b/spec/veeqo/shipment_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe Veeqo::Shipment do
     end
   end
 
+  describe ".delete" do
+    it "deletes a spcified shipment" do
+      shipment_id = 123
+
+      stub_veeqo_shipment_delete_api(shipment_id)
+      shipment_deletion = Veeqo::Shipment.delete(shipment_id)
+
+      expect(shipment_deletion.successful?).to be_truthy
+    end
+  end
+
   def shipment_attributes
     {
       order_id: 1,


### PR DESCRIPTION
This commit adds the interface to delete an existing shipment using the Veeqo API. To delete a shipment simply we can use

```ruby
Veeqo::Shipment.delete(shipment_id)
```