### PR TITLE
Remove `list` related spec duplications

### DIFF
--- a/spec/veeqo/actions/list_spec.rb
+++ b/spec/veeqo/actions/list_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe Veeqo::Actions::List do
+  describe ".list" do
+    context "without any filter arguments" do
+      it "retrieves the list of all items" do
+        stub_veeqo_product_list_api
+
+        items = TestProduct.list
+
+        expect(items.count).to eq(1)
+        expect(items.first.id).not_to be_nil
+      end
+    end
+
+    context "with custom filter arguments" do
+      it "retrieves the list of filterred item" do
+        filters = { page: 1, page_size: 10 }
+
+        stub_veeqo_product_list_api(filters)
+        items = TestProduct.list(filters)
+
+        expect(items.count).to eq(1)
+        expect(items.first.id).not_to be_nil
+      end
+    end
+  end
+
+  class TestProduct < Veeqo::Base
+    include Veeqo::Actions::List
+
+    private
+
+    def end_point
+      "products"
+    end
+  end
+end

--- a/spec/veeqo/customer_spec.rb
+++ b/spec/veeqo/customer_spec.rb
@@ -2,27 +2,14 @@ require "spec_helper"
 
 RSpec.describe Veeqo::Customer do
   describe ".list" do
-    context "without any filters" do
-      it "retrieves the list of customers" do
-        stub_veeqo_customer_list_api
-        customers = Veeqo::Customer.list
+    it "retrieves the list of all customers" do
+      filters = { page: 1, page_size: 12 }
 
-        expect(customers.count).to eq(1)
-        expect(customers.first.id).not_to be_nil
-        expect(customers.first.email).not_to be_nil
-      end
-    end
+      stub_veeqo_customer_list_api(filters)
+      customers = Veeqo::Customer.list(filters)
 
-    context "with custom filters" do
-      it "retrieves the specified customers" do
-        filters = { page: 1, page_size: 12 }
-
-        stub_veeqo_customer_list_api(filters)
-        customers = Veeqo::Customer.list(filters)
-
-        expect(customers.count).to eq(1)
-        expect(customers.first.id).not_to be_nil
-      end
+      expect(customers.count).to eq(1)
+      expect(customers.first.id).not_to be_nil
     end
   end
 

--- a/spec/veeqo/order_spec.rb
+++ b/spec/veeqo/order_spec.rb
@@ -2,26 +2,14 @@ require "spec_helper"
 
 RSpec.describe Veeqo::Order do
   describe ".list" do
-    context "without any filters" do
-      it "retrives the list of orders" do
-        stub_veeqo_order_list_api
-        orders = Veeqo::Order.list
+    it "retrives the all of the orders" do
+      filters = { page: "2", page_size: "25" }
 
-        expect(orders.count).to eq(1)
-        expect(orders.first.id).to eq(123)
-      end
-    end
+      stub_veeqo_order_list_api(filters)
+      orders = Veeqo::Order.list(filters)
 
-    context "with some custom filters" do
-      it "retrives the list based on the filter" do
-        filters = { page: "2", page_size: "25" }
-
-        stub_veeqo_order_list_api(filters)
-        orders = Veeqo::Order.list(filters)
-
-        expect(orders.count).to eq(1)
-        expect(orders.first.id).to eq(123)
-      end
+      expect(orders.count).to eq(1)
+      expect(orders.first.id).to eq(123)
     end
   end
 

--- a/spec/veeqo/product_spec.rb
+++ b/spec/veeqo/product_spec.rb
@@ -2,26 +2,14 @@ require "spec_helper"
 
 RSpec.describe Veeqo::Product do
   describe ".list" do
-    context "without any filters" do
-      it "retrieve the lists of products" do
-        stub_veeqo_product_list_api
-        products = Veeqo::Product.list
+    it "retrieve the lists of products" do
+      product_filters = { page_size: 10 }
 
-        expect(products.count).to eq(1)
-        expect(products.first.id).not_to be_nil
-      end
-    end
+      stub_veeqo_product_list_api(product_filters)
+      products = Veeqo::Product.list(product_filters)
 
-    context "with custom filters" do
-      it "retrieve product list based on filters" do
-        product_filters = { page_size: 10 }
-
-        stub_veeqo_product_list_api(product_filters)
-        products = Veeqo::Product.list(product_filters)
-
-        expect(products.count).to eq(1)
-        expect(products.first.id).not_to be_nil
-      end
+      expect(products.count).to eq(1)
+      expect(products.first.id).not_to be_nil
     end
   end
 

--- a/spec/veeqo/purchase_order_spec.rb
+++ b/spec/veeqo/purchase_order_spec.rb
@@ -2,25 +2,13 @@ require "spec_helper"
 
 RSpec.describe Veeqo::PurchaseOrder do
   describe ".list" do
-    context "with out any parameter" do
-      it "retrieves the purchase orders" do
-        stub_veeqo_purchase_order_list_api
-        purchase_orders = Veeqo::PurchaseOrder.list
+    it "retrieves the list of purchase orders" do
+      filter_hash = { page: 2, page_size: 10 }
+      stub_veeqo_purchase_order_list_api(filter_hash)
+      purchase_orders = Veeqo::PurchaseOrder.list(filter_hash)
 
-        expect(purchase_orders.count).to eq(1)
-        expect(purchase_orders.first.id).not_to be_nil
-      end
-    end
-
-    context "with additiona hash params" do
-      it "retrieves more precise purchase orders" do
-        filter_hash = { page: 2, page_size: 10 }
-        stub_veeqo_purchase_order_list_api(filter_hash)
-        purchase_orders = Veeqo::PurchaseOrder.list(filter_hash)
-
-        expect(purchase_orders.count).to eq(1)
-        expect(purchase_orders.first.id).not_to be_nil
-      end
+      expect(purchase_orders.count).to eq(1)
+      expect(purchase_orders.first.id).not_to be_nil
     end
   end
 end

--- a/spec/veeqo/supplier_spec.rb
+++ b/spec/veeqo/supplier_spec.rb
@@ -2,26 +2,14 @@ require "spec_helper"
 
 RSpec.describe Veeqo::Supplier do
   describe ".list" do
-    context "without any filter params" do
-      it "retrieves the list of suppliers" do
-        stub_veeqo_supplier_list_api
-        suppliers = Veeqo::Supplier.list
+    it "retrieves the list of suppliers" do
+      filters = { page: 1, page_size: 12 }
 
-        expect(suppliers.count).to eq(1)
-        expect(suppliers.first.id).not_to be_nil
-      end
-    end
+      stub_veeqo_supplier_list_api(filters)
+      suppliers = Veeqo::Supplier.list(filters)
 
-    context "with additional filters" do
-      it "retrives the spcified suppliers" do
-        filters = { page: 1, page_size: 12 }
-
-        stub_veeqo_supplier_list_api(filters)
-        suppliers = Veeqo::Supplier.list(filters)
-
-        expect(suppliers.count).to eq(1)
-        expect(suppliers.first.id).not_to be_nil
-      end
+      expect(suppliers.count).to eq(1)
+      expect(suppliers.first.id).not_to be_nil
     end
   end
 

--- a/spec/veeqo/warehouse_spec.rb
+++ b/spec/veeqo/warehouse_spec.rb
@@ -2,26 +2,14 @@ require "spec_helper"
 
 RSpec.describe Veeqo::Warehouse do
   describe ".list" do
-    context "without any filters" do
-      it "retrieves the list of warehouses" do
-        stub_veeqo_warehouse_list_api
-        warehouses = Veeqo::Warehouse.list
+    it "retrieves the list of warehouses" do
+      filters = { page: 1, page_size: 12 }
 
-        expect(warehouses.count).to eq(1)
-        expect(warehouses.first.id).not_to be_nil
-      end
-    end
+      stub_veeqo_warehouse_list_api(filters)
+      warehouses = Veeqo::Warehouse.list(filters)
 
-    context "with custom filters" do
-      it "retrieves the list based on the filters" do
-        filters = { page: 1, page_size: 12 }
-
-        stub_veeqo_warehouse_list_api(filters)
-        warehouses = Veeqo::Warehouse.list(filters)
-
-        expect(warehouses.count).to eq(1)
-        expect(warehouses.first.id).not_to be_nil
-      end
+      expect(warehouses.count).to eq(1)
+      expect(warehouses.first.id).not_to be_nil
     end
   end
 


### PR DESCRIPTION
The `.list` API supports one additional parameter, which can be used to filter the listing, but we are repeating that in every resources's `list` spec, which is kind of a duplication.

Now that we have moved `list` action to a module, so it makes more sense to move those `list` specific edge cases a spec that will test that module.