### PR TITLE
Add interface to update an allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ Veeqo::Allocation.create(
 )
 ```
 
+#### Update a allocation details
+
+```ruby
+Veeqo::Allocation.update(
+  allocation_id,
+  order_id: 123_456,
+  warehouse_id: 456_789,
+  line_items: [{
+    quantity: 2,
+    sellable_id: 123_456,
+  }],
+)
+```
+
 ### Product
 
 Resources related to the products in the API.

--- a/lib/veeqo/allocation.rb
+++ b/lib/veeqo/allocation.rb
@@ -8,6 +8,14 @@ module Veeqo
       )
     end
 
+    def update(allocation_id, order_id:, line_items:, **attributes)
+      @order_id = order_id
+      update_resource(
+        allocation_id,
+        attributes.merge(line_items_attributes: line_items),
+      )
+    end
+
     private
 
     def end_point

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -348,6 +348,16 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_allocation_update_api(id, order_id:, line_items:, **attrs)
+    stub_api_response(
+      :put,
+      ["orders", order_id, "allocations", id].compact.join("/"),
+      data: attrs.merge(line_items_attributes: line_items),
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/allocation_spec.rb
+++ b/spec/veeqo/allocation_spec.rb
@@ -11,6 +11,19 @@ RSpec.describe Veeqo::Allocation do
     end
   end
 
+  describe ".update" do
+    it "updates an existing allocation" do
+      allocation_id = 123_456
+
+      stub_veeqo_allocation_update_api(allocation_id, allocation_attributes)
+      allocation_update = Veeqo::Allocation.update(
+        allocation_id, allocation_attributes
+      )
+
+      expect(allocation_update.successful?).to be_truthy
+    end
+  end
+
   def allocation_attributes
     {
       order_id: 447452,


### PR DESCRIPTION
This commit implements the interface to update an existing allocation using the Veeqo API. It requires an `allocation_id` and a valid `order_id` to successfully update the allocation

```ruby
Veeqo::Allocation.update(
  allocation_id,
  order_id: 123_456,
  warehouse_id: 456_789,
  line_items: [{
    quantity: 2,
    sellable_id: 123_456,
  }],
)
```