### PR TITLE
Add interface to delete an allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Veeqo::Allocation.update(
 )
 ```
 
+#### Delete an existing allocation
+
+```ruby
+Veeqo::Allocation.delete(order_id, allocation_id)
+```
+
 ### Product
 
 Resources related to the products in the API.

--- a/lib/veeqo/allocation.rb
+++ b/lib/veeqo/allocation.rb
@@ -1,5 +1,7 @@
 module Veeqo
   class Allocation < Base
+    include Veeqo::Actions::Delete
+
     def create(order_id:, warehouse_id:, line_items:)
       @order_id = order_id
       create_resource(
@@ -14,6 +16,11 @@ module Veeqo
         allocation_id,
         attributes.merge(line_items_attributes: line_items),
       )
+    end
+
+    def delete(order_id, allocation_id)
+      @order_id = order_id
+      super(allocation_id)
     end
 
     private

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -358,6 +358,15 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_allocation_delete_api(order_id, allocation_id)
+    stub_api_response(
+      :delete,
+      ["orders", order_id, "allocations", allocation_id].join("/"),
+      filename: "empty",
+      status: 204,
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/allocation_spec.rb
+++ b/spec/veeqo/allocation_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe Veeqo::Allocation do
     end
   end
 
+  describe ".delete" do
+    it "deletes the specified allocation" do
+      order_id = 123_456
+      allocation_id = 456_789
+
+      stub_veeqo_allocation_delete_api(order_id, allocation_id)
+      allocation_delete = Veeqo::Allocation.delete(order_id, allocation_id)
+
+      expect(allocation_delete.successful?).to be_truthy
+    end
+  end
+
   def allocation_attributes
     {
       order_id: 447452,


### PR DESCRIPTION
This commits adds the interface to delete an existing allocation, to delete an allocation we can use the `.delete` as

```ruby
Veeqo::Allocation.delete(order_id, allocation_id)
```