### PR TITLE
Add `#parse` to `Veeqo::Request`

### DIFF
--- a/lib/veeqo/actions/delete.rb
+++ b/lib/veeqo/actions/delete.rb
@@ -4,7 +4,7 @@ module Veeqo
   module Actions
     module Delete
       def delete(resource_id)
-        Veeqo::Request.new(:delete, [end_point, resource_id].join("/")).run
+        Veeqo::Request.new(:delete, [end_point, resource_id].join("/")).parse
       end
     end
   end

--- a/lib/veeqo/actions/find.rb
+++ b/lib/veeqo/actions/find.rb
@@ -4,7 +4,7 @@ module Veeqo
   module Actions
     module Find
       def find(resource_id)
-        Veeqo::Request.new(:get, [end_point, resource_id].join("/")).run
+        Veeqo::Request.new(:get, [end_point, resource_id].join("/")).parse
       end
     end
   end

--- a/lib/veeqo/actions/list.rb
+++ b/lib/veeqo/actions/list.rb
@@ -4,7 +4,7 @@ module Veeqo
   module Actions
     module List
       def list(filters = {})
-        Veeqo::Request.new(:get, end_point, filters).run
+        Veeqo::Request.new(:get, end_point, filters).parse
       end
     end
   end

--- a/lib/veeqo/base.rb
+++ b/lib/veeqo/base.rb
@@ -14,13 +14,13 @@ module Veeqo
     private
 
     def create_resource(attributes)
-      Veeqo::Request.new(:post, end_point, attributes).run
+      Veeqo::Request.new(:post, end_point, attributes).parse
     end
 
     def update_resource(resource_id, attributes)
       Veeqo::Request.new(
         :put, [end_point, resource_id].join("/"), attributes
-      ).run
+      ).parse
     end
   end
 end

--- a/lib/veeqo/company.rb
+++ b/lib/veeqo/company.rb
@@ -1,11 +1,11 @@
 module Veeqo
   class Company < Base
     def find
-      Veeqo::Request.new(:get, end_point).run
+      Veeqo::Request.new(:get, end_point).parse
     end
 
     def update(attributes)
-      Veeqo::Request.new(:put, end_point, attributes).run
+      Veeqo::Request.new(:put, end_point, attributes).parse
     end
 
     private

--- a/lib/veeqo/request.rb
+++ b/lib/veeqo/request.rb
@@ -11,7 +11,11 @@ module Veeqo
     end
 
     def run
-      Response.new(send_http_request).parse
+      send_http_request
+    end
+
+    def parse
+      Response.new(run).parse
     end
 
     private

--- a/spec/veeqo/request_spec.rb
+++ b/spec/veeqo/request_spec.rb
@@ -2,9 +2,18 @@ require "spec_helper"
 
 RSpec.describe Veeqo::Request do
   describe "#run" do
-    it "retrieves the parsed resource in specified http verb" do
+    it "executes the http request with specified verb" do
       stub_ping_request_via_get
       response = Veeqo::Request.new(:get, "ping").run
+
+      expect(response.code.to_i).to eq(200)
+    end
+  end
+
+  describe "#parse" do
+    it "runs the request and parse the response" do
+      stub_ping_request_via_get
+      response = Veeqo::Request.new(:get, "ping").parse
 
       expect(response.data).to eq("Pong!")
     end


### PR DESCRIPTION
The existing interface for `Veeqo::Request` might creates some confusion, as we have a method name `#run` and that is actually executing the request and at the same time it is also parsing the API response, which is bit confusing.

This commit rename it to `#parse` and add one additional `#run` method, which will only run the API request without doing any parsing. So if we do not need to parse the response then we can use the `#run` but if we do need to parse then use `#parse`.