### PR TITLE
Add custom errors for invalid responses

### DIFF
--- a/lib/veeqo/errors.rb
+++ b/lib/veeqo/errors.rb
@@ -1,0 +1,30 @@
+require "veeqo/errors/request_error"
+require "veeqo/errors/forbidden"
+require "veeqo/errors/server_error"
+require "veeqo/errors/unauthorized"
+
+module Veeqo
+  module Errors
+    def self.server_errors
+      [
+        OpenSSL::SSL::SSLError,
+        Errno::ETIMEDOUT,
+        Errno::EHOSTUNREACH,
+        Errno::ENETUNREACH,
+        Errno::ECONNRESET,
+        Net::OpenTimeout,
+        SocketError,
+        Net::HTTPServerError,
+      ]
+    end
+
+    def self.error_klass_for(response)
+      case response
+      when *server_errors then Errors::ServerError
+      when Net::HTTPUnauthorized then Errors::Unauthorized
+      when Net::HTTPForbidden then Errors::Forbidden
+      else Errors::RequestError
+      end
+    end
+  end
+end

--- a/lib/veeqo/errors/forbidden.rb
+++ b/lib/veeqo/errors/forbidden.rb
@@ -1,0 +1,9 @@
+module Veeqo
+  module Errors
+    class Forbidden < RequestError
+      def explanation
+        "A request to Veeqo API was considered forbidden by the server"
+      end
+    end
+  end
+end

--- a/lib/veeqo/errors/request_error.rb
+++ b/lib/veeqo/errors/request_error.rb
@@ -1,0 +1,15 @@
+module Veeqo
+  module Errors
+    class RequestError < StandardError
+      def message
+        explanation
+      end
+
+      def explanation
+        "A request to Veeqo API failed"
+      end
+    end
+  end
+
+  Error = Errors::RequestError
+end

--- a/lib/veeqo/errors/server_error.rb
+++ b/lib/veeqo/errors/server_error.rb
@@ -1,0 +1,9 @@
+module Veeqo
+  module Errors
+    class ServerError < RequestError
+      def explanation
+        "A request to Veeqo API caused an unexpected server error"
+      end
+    end
+  end
+end

--- a/lib/veeqo/errors/unauthorized.rb
+++ b/lib/veeqo/errors/unauthorized.rb
@@ -1,0 +1,9 @@
+module Veeqo
+  module Errors
+    class Unauthorized < RequestError
+      def explanation
+        "A request to Veeqo API was sent without a valid authentication"
+      end
+    end
+  end
+end

--- a/spec/veeqo/request_spec.rb
+++ b/spec/veeqo/request_spec.rb
@@ -2,11 +2,22 @@ require "spec_helper"
 
 RSpec.describe Veeqo::Request do
   describe "#run" do
-    it "executes the http request with specified verb" do
-      stub_ping_request_via_get
-      response = Veeqo::Request.new(:get, "ping").run
+    context "with 2xx response" do
+      it "retrieves a resource via specified http verb" do
+        stub_ping_request_via_get
+        response = Veeqo::Request.new(:get, "ping").run
 
-      expect(response.code.to_i).to eq(200)
+        expect(response.code.to_i).to eq(200)
+      end
+    end
+
+    context "with 4xx, 5xx response" do
+      it "raises the proper response error" do
+        stub_invalid_ping_request_via_get
+        request = Veeqo::Request.new(:get, "invalid")
+
+        expect { request.run }.to raise_error(Veeqo::Errors::ServerError)
+      end
     end
   end
 
@@ -21,5 +32,9 @@ RSpec.describe Veeqo::Request do
 
   def stub_ping_request_via_get
     stub_api_response(:get, "ping", status: 200, filename: "ping")
+  end
+
+  def stub_invalid_ping_request_via_get
+    stub_api_response(:get, "invalid", status: 503, filename: "ping")
   end
 end


### PR DESCRIPTION
We were responding with `net/http`'s default errors, but this might creates some problem as some other API client might also response with the same error class and that will make it harder for developer to debug/rescue.

This commit adds the `Veeqo::Errors` specified custom errors, so whenever there is an invalid response then it will raise the appropriate error form the `Veeqo::Errors` module.