### PR TITLE
Add version badge for latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 Status](https://travis-ci.org/abunashir/veeqo.svg?branch=master)](https://travis-ci.org/abunashir/veeqo)
 [![Code
 Climate](https://codeclimate.com/github/abunashir/veeqo/badges/gpa.svg)](https://codeclimate.com/github/abunashir/veeqo)
+[![Gem
+Version](https://badge.fury.io/rb/veeqo.svg)](https://badge.fury.io/rb/veeqo)
 
 The Ruby Interface to the Veeqo API
 


### PR DESCRIPTION
Version Badge provides a consistent way for the Ruby community to learn about the RubyGem associated with a particular Github repo and other documentation pages.