### PR TITLE
Fix `#initialize_http_header` related issue

### DIFF
--- a/lib/veeqo/request.rb
+++ b/lib/veeqo/request.rb
@@ -74,8 +74,10 @@ module Veeqo
     end
 
     def set_request_headers!(request)
-      request.initialize_http_header("Content-Type" => "application/json")
-      request.initialize_http_header("x-api-key" => Veeqo.configuration.api_key)
+      request.initialize_http_header(
+        "Content-Type" => "application/json",
+        "x-api-key" => Veeqo.configuration.api_key,
+      )
     end
 
     def server_errors

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -392,7 +392,10 @@ module FakeVeeqoApi
   end
 
   def api_key_header
-    { "x-api-key" => Veeqo.configuration.api_key }
+    {
+      "content-type" => "application/json",
+      "x-api-key" => Veeqo.configuration.api_key,
+    }
   end
 
   def response_with(filename:, status:)


### PR DESCRIPTION
In the `Veeqo::Request` we're using `#initialize_http_header` to set API key and `Content-Type` header separately. But the way `#initialize_http_header` work, every call to this method resets the header and reinitialize with provided hash's key value pair

This was causing not to set the headers properly, last call to the `#initialize_http_header` was overriding any other headers.

This commit fixes this, Now all headers should have been setted up properly and work like a charm :)

Ref: https://github.com/ruby/ruby/blob/trunk/lib/net/http/header.rb#L14