### PR TITLE
Add interface to list all tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,16 @@ Veeqo::Shipment.create(
 )
 ```
 
+### Tags
+
+Resources related to the order tags in the API.
+
+#### List All Tags
+
+```ruby
+Veeqo::Tag.list
+```
+
 #### Delete a shipment
 
 ```ruby

--- a/lib/veeqo.rb
+++ b/lib/veeqo.rb
@@ -11,6 +11,7 @@ require "veeqo/customer"
 require "veeqo/store"
 require "veeqo/delivery_method"
 require "veeqo/shipment"
+require "veeqo/tag"
 
 module Veeqo
 end

--- a/lib/veeqo/tag.rb
+++ b/lib/veeqo/tag.rb
@@ -1,0 +1,11 @@
+module Veeqo
+  class Tag < Base
+    include Veeqo::Actions::List
+
+    private
+
+    def end_point
+      "tags"
+    end
+  end
+end

--- a/spec/fixtures/tags.json
+++ b/spec/fixtures/tags.json
@@ -1,0 +1,16 @@
+[
+  {
+    "colour": "#300084",
+    "company_id": 1422,
+    "id": 4405,
+    "name": "Need Stock",
+    "taggings_count": 1
+  },
+  {
+    "colour": "#333399",
+    "company_id": 1422,
+    "id": 11159,
+    "name": "Give me a name",
+    "taggings_count": 0
+  }
+]

--- a/spec/support/fake_veeqo_api.rb
+++ b/spec/support/fake_veeqo_api.rb
@@ -369,6 +369,12 @@ module FakeVeeqoApi
     )
   end
 
+  def stub_veeqo_tag_list_api
+    stub_api_response(
+      :get, "tags", filename: "tags", status: 200
+    )
+  end
+
   private
 
   def stub_api_response(method, end_point, filename:, status:, data: nil)

--- a/spec/veeqo/tag_spec.rb
+++ b/spec/veeqo/tag_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+RSpec.describe Veeqo::Tag do
+  describe ".list" do
+    it "retrieves the list of tags" do
+      stub_veeqo_tag_list_api
+      tags = Veeqo::Tag.list
+
+      expect(tags.count).to eq(2)
+      expect(tags.first.id).not_to be_nil
+      expect(tags.first.name).to eq("Need Stock")
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the interface to list all the tags using the Veeqo API. To list the tags you can use

```ruby
Veeqo::Tag.list
```